### PR TITLE
MCS-367: Update layer compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -38,5 +38,5 @@ LAYERDEPENDS_oatpp = "core"
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
 LAYERVERSION_oatpp = "1"
-LAYERSERIES_COMPAT_oatpp = "kirkstone"
+LAYERSERIES_COMPAT_oatpp = "kirkstone scarthgap"
 


### PR DESCRIPTION
**Why?**

Since oatpp meta-layer does depend on Yocto release cycle (currently the newest, and the only one is duffel) I update compatibility since kas fails to start even shell without having the layer compatible.

I assume we'd stay at this branch until we detect some changes required as result of newer bitbake.